### PR TITLE
ci(node): CI test for Node bindings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,15 @@ jobs:
       - uses: actions/setup-node@v4
       - run: npm install
       - run: npm run test-corpus
+  node-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - uses: actions/setup-node@v4
+      - run: npm install
+      - run: npm test
   rust-tests:
     runs-on: ubuntu-latest
     steps:

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,12 +7,12 @@
       ],
       "include_dirs": [
         "src",
+        "vendor/tree-sitter-markdown/tree-sitter-markdown/src",
       ],
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
         "src/scanner.c",
-        "vendor/tree-sitter-markdown/tree-sitter-markdown/src/scanner.c",
       ],
       "conditions": [
         ["OS!='win'", {

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -14,6 +14,9 @@ fn main() {
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
+    // The markdown external scanner is vendored into the project, and included in our own external
+    // scanner implementation. Include it as a file to watch for changes, but don't include it as
+    // its own source file.
     let mut md_scanner_path = vendor_dir.to_owned();
     md_scanner_path.extend([
         "tree-sitter-markdown",
@@ -21,7 +24,6 @@ fn main() {
         "src",
         "scanner.c",
     ]);
-    c_config.file(&md_scanner_path);
     println!(
         "cargo:rerun-if-changed={}",
         md_scanner_path.to_str().unwrap()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "tree-sitter playground",
     "test": "node --test bindings/node/*_test.js",
     "test-corpus": "tree-sitter test",
-    "generate": "tree-sitter generate"
+    "generate": "tree-sitter generate --no-bindings"
   },
   "keywords": [
     "treesitter",
@@ -21,8 +21,8 @@
   ],
   "files": [
     "grammar.js",
-    "binding.gyp",
     "prebuilds/**",
+    "binding.gyp",
     "bindings/node/*",
     "queries/*",
     "src/**",


### PR DESCRIPTION
Note that `npm install` also builds the native parts of the node bindings, so it needs to be called before running tests.